### PR TITLE
修改问题：信息列表面板，来源网址字段，文本过长时的显示压盖问题

### DIFF
--- a/apps/limitEditor/editor/components/left-panels/infoList/infoListPanelTpl.html
+++ b/apps/limitEditor/editor/components/left-panels/infoList/infoListPanelTpl.html
@@ -120,7 +120,7 @@
                 </li>
                 <li class="multi-line">
                     <span class="left">来源网址：</span>
-                    <span>{{url}}</span>
+                    <span class="long-text">{{url}}</span>
                 </li>
                 <li>
                     <span class="left">发布日期：</span>

--- a/apps/limitEditor/editor/components/left-panels/infoList/infoListPanelTpl.html
+++ b/apps/limitEditor/editor/components/left-panels/infoList/infoListPanelTpl.html
@@ -73,11 +73,12 @@
         vertical-align: top;
         text-align: right;
     }
-    .infoListPanel .content span.long-text {
+    .infoListPanel .content a.long-text {
         display: inline-block;
         width: 170px;
         word-break: break-all;
         word-wrap: break-word;
+        cursor: pointer;
     }
 </style>
 <div ng-controller="infoListPanelCtl" class="infoListPanel">
@@ -120,7 +121,7 @@
                 </li>
                 <li class="multi-line">
                     <span class="left">来源网址：</span>
-                    <span class="long-text">{{url}}</span>
+                    <a class="long-text" href="{{url}}" target="_blank">{{url}}</a>
                 </li>
                 <li>
                     <span class="left">发布日期：</span>

--- a/apps/limitEditor/editor/components/left-panels/infoList/infoListPanelTpl.html
+++ b/apps/limitEditor/editor/components/left-panels/infoList/infoListPanelTpl.html
@@ -46,6 +46,11 @@
         height: 30px;
         line-height: 30px;
     }
+    .infoListPanel .content ul li.multi-line {
+        height: inherit;
+        line-height: 18px;
+        padding: 6px 0;
+    }
     .infoListPanel .content ul textarea {
         margin-left: 10px;
         margin-bottom: 10px;
@@ -67,6 +72,12 @@
         margin: 0 10px;
         vertical-align: top;
         text-align: right;
+    }
+    .infoListPanel .content span.long-text {
+        display: inline-block;
+        width: 170px;
+        word-break: break-all;
+        word-wrap: break-word;
     }
 </style>
 <div ng-controller="infoListPanelCtl" class="infoListPanel">
@@ -107,7 +118,7 @@
                     <span class="left">情报编码：</span>
                     <span>{{infoCode}}</span>
                 </li>
-                <li>
+                <li class="multi-line">
                     <span class="left">来源网址：</span>
                     <span>{{url}}</span>
                 </li>


### PR DESCRIPTION
1. 修改来源网址字段，文本过长时的显示压盖问题，修改后为换行显示。
2. 来源网址字段，改为用 <a>标签实现，点击后，新窗口打开网址。